### PR TITLE
Change BETA KeyCloak URL

### DIFF
--- a/.env
+++ b/.env
@@ -25,4 +25,4 @@ VITE_SERVER_INT_KEYCLOAK_URL = https://centralidp.int.demo.catena-x.net/auth
 
 VITE_SERVER_BETA_LABEL = BETA Environment
 VITE_SERVER_BETA_BASE_URL = https://irs.beta.demo.catena-x.net
-VITE_SERVER_BETA_KEYCLOAK_URL = https://centralidp.int.demo.catena-x.net/auth
+VITE_SERVER_BETA_KEYCLOAK_URL = https://centralidp.beta.demo.catena-x.net/auth


### PR DESCRIPTION
I've noticed that the URL of BETA keycloak is not correct. 
I provided a quick fix with the correct URL